### PR TITLE
fix(Dockerfile): Update build-image and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,12 @@ RUN make build-binary
 
 WORKDIR /root
 
+FROM debian:bullseye-slim
+
+RUN apt-get -qqy update && \
+    apt-get -qqy install git-core && \
+    apt-get -qqy autoclean && \
+    apt-get -qqy autoremove
+
 COPY --from=build /app/kost ./
 ENTRYPOINT ["./kost"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-image:
 	docker build --build-arg GO_LDFLAGS="$(GO_LDFLAGS)" -t $(IMAGE_PREFIX)/$(IMAGE_NAME) -t $(IMAGE_NAME_VERSION) .
 
 build-binary:
-	CGO_ENABLED=0 go build -v -ldflags "$(GO_LDFLAGS)" -o kost ./cmd/exporter
+	CGO_ENABLED=0 go build -v -ldflags "$(GO_LDFLAGS)" -o kost ./cmd/bot
 
 build: build-binary build-image
 


### PR DESCRIPTION
In the latest [push to main](https://github.com/grafana/Kost/actions/runs/11351845364/job/31573311568), there was an error building and publishing the image:

```bash
Error: buildx failed with: ERROR: failed to solve: circular dependency detected on stage: build
```

This updates the Dockerfile to split out the build and package stages and ensures the `build-binary` has the proper entrypoint for the build command.