### PR TITLE
Update clients to handle GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ IMAGE_PREFIX=grafana
 IMAGE_NAME=kost
 IMAGE_NAME_LATEST=${IMAGE_PREFIX}/${IMAGE_NAME}:latest
 IMAGE_NAME_VERSION=$(IMAGE_PREFIX)/$(IMAGE_NAME):$(VERSION)
+DIVE_HIGHEST_USER_WASTED_PERCENT := 0.15
 
 PROM_VERSION_PKG ?= github.com/prometheus/common/version
 BUILD_USER   ?= $(shell whoami)@$(shell hostname)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Specifically, the following assumptions need to be met:
 - K8s resources defined in a standalone repository
   - We use [jsonnet](https://jsonnet.org/) to define resources + [tanka](https://tanka.dev/) to generate the k8s manifest files and commit them to a `kube-manifest` repo + [flux](https://fluxcd.io/) to deploy them to clusters
 - Mimir to store [opencost](https://github.com/opencost/opencost) + [cloudcost-exporter](https://github.com/grafana/cloudcost-exporter) metrics for cost data
-- Drone(soon to be GitHub Actions) to detect changes and run the cost report
+- GitHub Actions to detect changes and run the cost report
 
 While these are what we use internally and require, in theory the bot should work so long as you have:
 1. Two manifest files that you can compare changes
-2. Prometheus complient backend with cost metrics
+2. Prometheus compliant backend with cost metrics
 3. A CI system to run the bot when changes happen
 
 
@@ -45,7 +45,7 @@ There are two entrypoints that you can run:
 - bot
 
 Estimator is a simple cli that accepts two manifest files and a set of clusters to generate the cost estimator for.
-Bot is what is ran in Drone today and requires the `kube-manifest` repository to be available locally.
+Bot is what is ran in GitHub Actions today and requires the `kube-manifest` repository to be available locally.
 
 ## Estimator
 
@@ -76,8 +76,8 @@ Set the following environment variables:
 - `KUBE_MANIFESTS_PATH`: path to `grafana/kube-manifests`
 - `HTTP_CONFIG_FILE`: path to configuration created in [Prereqs](#prerequisites)
 - `PROMETHEUS_ADDRESS`: mimir endpoint
-- `DRONE_PULL_REQUEST`: GitHub PR to create comment on
-- `DRONE_BUILD_EVENT `: set to `pull_request`
+- `GITHUB_PULL_REQUEST`: GitHub PR to create comment on
+- `GITHUB_EVENT_NAME`: set to `pull_request`
 - `GITHUB_TOKEN`: set to a token that is able to comment on PRs
 - `CI`: set to `true`
 

--- a/cmd/bot/config.go
+++ b/cmd/bot/config.go
@@ -32,8 +32,8 @@ type config struct {
 	GitHub github.Config
 
 	IsCI     bool   `envconfig:"CI"`
-	PR       int    `envconfig:"DRONE_PULL_REQUEST" required:"true"`
-	Event    string `envconfig:"DRONE_BUILD_EVENT"`
+	PR       int    `envconfig:"GITHUB_PULL_REQUEST" required:"true"`
+	Event    string `envconfig:"GITHUB_EVENT_NAME"`
 	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
 }
 
@@ -56,7 +56,7 @@ func (c config) validate() error {
 	}
 
 	if c.PR == 0 || c.Event != pullRequestEvent {
-		return errors.New("expecting DRONE_PULL_REQUEST and DRONE_BUILD_EVENT to be set")
+		return errors.New("expecting GITHUB_PULL_REQUEST and GITHUB_EVENT_NAME to be set")
 	}
 
 	if err := c.GitHub.Validate(); err != nil {

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -73,14 +73,17 @@ func realMain(ctx context.Context) error {
 
 	repo := git.NewRepository(cfg.Manifests.RepoPath)
 
-	oldCommit := "master"
-	newCommit, err := repo.GetCurrentCommit(ctx)
+	oldCommit, err := repo.GetCommit(ctx, "HEAD^")
 	if err != nil {
-		return fmt.Errorf("getting current commit: %w", err)
+		return fmt.Errorf("getting commit: %w", err)
 	}
 
-	rev := oldCommit + "..." + newCommit
-	cf, err := repo.ChangedFiles(ctx, rev)
+	newCommit, err := repo.GetCommit(ctx, "HEAD")
+	if err != nil {
+		return fmt.Errorf("getting commit: %w", err)
+	}
+
+	cf, err := repo.ChangedFiles(ctx, oldCommit, newCommit)
 	if err != nil {
 		return err
 	}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -32,6 +33,7 @@ func NewClient(ctx context.Context, cfg Config) (Client, error) {
 	var token = cfg.Token
 
 	if cfg.AppID > 0 {
+		slog.Info("Using GitHub app authentication")
 		t, err := ghinstallation.NewAppsTransport(
 			httpcache.NewMemoryCacheTransport(),
 			cfg.AppID,
@@ -52,6 +54,8 @@ func NewClient(ctx context.Context, cfg Config) (Client, error) {
 		}
 
 		token = tok.GetToken()
+	} else {
+		slog.Info("Using GitHub token authentication")
 	}
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})


### PR DESCRIPTION
This is largely pulled from an internal change, and is necessary before cutting over internal usage to the generated container from this project.

Pulled from previous PR:

- Added some more logging + made `slog` work in GHA (with a default log level of info)
- Use the HEAD^ and HEAD refs as comparisons, the exporter will always create a single commit for a PR
- Updated Drone refs to be GitHub Actions
