### PR TITLE
Explicitly define entrypoint for kost app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN go mod download
 COPY . .
 RUN make build-binary
 
-WORKDIR /root
-
 FROM debian:bullseye-slim
 
 RUN apt-get -qqy update && \
@@ -17,5 +15,5 @@ RUN apt-get -qqy update && \
     apt-get -qqy autoclean && \
     apt-get -qqy autoremove
 
-COPY --from=build /app/kost ./
-ENTRYPOINT ["./kost"]
+COPY --from=build /app/kost /app/
+ENTRYPOINT ["/app/kost"]


### PR DESCRIPTION
After rolling the change out to our internal systems, it was failing with the following error message:

```
Unable to find image 'grafana/kost:latest' locallylatest: Pulling from
internal61a05b: Pulling fs layerec31cd2b3349: Pulling fs
layerec31cd2b3349: Verifying Checksumec31cd2b3349: Download
complete89320e7119e2: Verifying Checksum89320e7119e2: Download
completec9e7f561a05b: Verifying Checksumc9e7f561a05b: Download
complete89320e7119e2: Pull completec9e7f561a05b: Pull
completeec31cd2b3349: Pull completeDigest:
sha256:884a38041601c23cf471fef574e267d16d225f9047d8f3de143dbc770a90726fStatus:
Downloaded newer image for grafana/kost:latestdocker: Error response
from daemon: failed to create task for container: failed to create shim
task: OCI runtime create failed: runc create failed: unable to start
container process: exec: "./kost": stat ./kost: no such file or
directory: unknown.
```

After pulling the image locally, I noticed that there was no binary for `kost`.

This explicitly sets the entrypoint for kost to be `/app/kost` and removes `WORKDIR /root`.