### PR TITLE
Add GitHub Action to support releases on tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build and push
         uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # 5.1.0
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # 6.1.0
+        with:
+          distribution: goreleaser
+          version: 2
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+# Make sure to check the documentation at https://goreleaser.com
+
+version: 2
+
+project_name: kost
+builds:
+  - id: kost
+    binary: kost
+    main: ./cmd/bot/main.go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs'
+      - '^chore(deps):'

--- a/docs/contribute/release.md
+++ b/docs/contribute/release.md
@@ -1,0 +1,45 @@
+# Release Process
+
+## Building images
+
+There is a [GitHub Workflow](../../.github/workflows/docker.yml) that publishes images on changes to `main` and new tags.
+
+## Versioning
+
+We follow [semver](https://semver.org/) and generate new tags manually.
+
+To cut a release, clone `kost` locally and pull latest from main.
+Determine if the next release is a major, minor, or hotfix.
+Then increment the relevant version label.
+
+For instance, let's say we're on `v0.2.2` and determined the next release is a minor change.
+The next version would then be `v0.3.0`.
+Execute the following command to generate the tag and push it:
+
+```sh
+git tag v0.3.0
+# Optionally, add a message on why the specific version label was updated: git tag v0.3.0 -m "Adds liveness probes with backwards compatibility"
+git push origin tag v0.3.0
+```
+
+## Releases
+
+Creating and pushing a new tag will trigger the `goreleaser` workflow in [./.github/workflows/release.yml](https://github.com/grafana/cloudcost-exporter/tree/main/.github/workflows/release.yml).
+
+The configuration for `goreleaser` itself can be found in [./.goreleaser.yaml](https://github.com/grafana/cloudcost-exporter/blob/main/.goreleaser.yaml).
+
+See https://github.com/grafana/cloudcost-exporter/issues/18 for progress on our path to automating releases.
+
+## GitHub Actions
+
+When adding or upgrading a GitHub Actions `actions`, please set the full length commit SHA instead of the version:
+
+```
+jobs:
+  myjob:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: foo/baraction@abcdef1234567890abcdef1234567890abcdef12 # v1.2.3
+```
+
+Granular control of the version helps with security since commit SHAs are immutable.


### PR DESCRIPTION
Introduces a new action 'release' which is triggered by changes that have tags prefixed with `v`.
This triggers a [goreleaser](https://goreleaser.com/) build that creates an executable and uploads the changes as a release to GitHub. Adds documentation on how to create a release.