### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ project_name: kost
 builds:
   - id: kost
     binary: kost
-    main: ./cmd/bot/main.go
+    main: ./cmd/bot
     env:
       - CGO_ENABLED=0
     goos:
@@ -16,7 +16,7 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
There was an error generating the build

```
│ cmd/bot/main.go:48:14: undefined: parseConfig
```

I believe this is because we set the entry point for the application to me `cmd/bot/main.go` causing go to not be able to find the dependencies. THis updates the entry point to be `./cmd/bot`.

There was also a warning for a deprecated flag:

```
 • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```

This was updated in the `.goreleaser.yaml` file.