### PR TITLE
Migrate to using cloudcost-exporter metrics

### DIFF
--- a/cmd/bot/config.go
+++ b/cmd/bot/config.go
@@ -31,10 +31,11 @@ type config struct {
 
 	GitHub github.Config
 
-	IsCI     bool   `envconfig:"CI"`
-	PR       int    `envconfig:"GITHUB_PULL_REQUEST" required:"true"`
-	Event    string `envconfig:"GITHUB_EVENT_NAME"`
-	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
+	IsCI                        bool   `envconfig:"CI"`
+	PR                          int    `envconfig:"GITHUB_PULL_REQUEST" required:"true"`
+	Event                       string `envconfig:"GITHUB_EVENT_NAME"`
+	LogLevel                    string `envconfig:"LOG_LEVEL" default:"info"`
+	UseCloudCostExporterMetrics bool   `envconfig:"USE_CLOUD_COST_EXPORTER" default:"false"`
 }
 
 const pullRequestEvent = "pull_request"

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -56,16 +56,18 @@ func realMain(ctx context.Context) error {
 
 	prometheusClients, err := costmodel.NewClients(
 		&costmodel.ClientConfig{
-			Address:        cfg.Prometheus.Prod.Address,
-			HTTPConfigFile: cfg.Prometheus.Prod.HTTPConfigFile,
-			Username:       cfg.Prometheus.Prod.Username,
-			Password:       cfg.Prometheus.Prod.Password,
+			Address:                     cfg.Prometheus.Prod.Address,
+			HTTPConfigFile:              cfg.Prometheus.Prod.HTTPConfigFile,
+			Username:                    cfg.Prometheus.Prod.Username,
+			Password:                    cfg.Prometheus.Prod.Password,
+			UseCloudCostExporterMetrics: cfg.UseCloudCostExporter,
 		},
 		&costmodel.ClientConfig{
-			Address:        cfg.Prometheus.Dev.Address,
-			HTTPConfigFile: cfg.Prometheus.Dev.HTTPConfigFile,
-			Username:       cfg.Prometheus.Dev.Username,
-			Password:       cfg.Prometheus.Dev.Password,
+			Address:                     cfg.Prometheus.Dev.Address,
+			HTTPConfigFile:              cfg.Prometheus.Dev.HTTPConfigFile,
+			Username:                    cfg.Prometheus.Dev.Username,
+			Password:                    cfg.Prometheus.Dev.Password,
+			UseCloudCostExporterMetrics: cfg.UseCloudCostExporter,
 		})
 	if err != nil {
 		return fmt.Errorf("creating cost model client: %w", err)

--- a/cmd/estimator/main.go
+++ b/cmd/estimator/main.go
@@ -11,6 +11,7 @@ import (
 
 func main() {
 	var fromFile, toFile, prometheusAddress, httpConfigFile, reportType, username, password string
+	var useCloudCostExporterMetrics bool
 	flag.StringVar(&fromFile, "from", "", "The file to compare from")
 	flag.StringVar(&toFile, "to", "", "The file to compare to")
 	flag.StringVar(&prometheusAddress, "prometheus.address", "http://localhost:9093/prometheus", "The Address of the prometheus server")
@@ -18,18 +19,19 @@ func main() {
 	flag.StringVar(&username, "username", "", "Mimir username")
 	flag.StringVar(&password, "password", "", "Mimir password")
 	flag.StringVar(&reportType, "report.type", "table", "The type of report to generate. Options are: table, summary")
+	flag.BoolVar(&useCloudCostExporterMetrics, "use.cloud.cost.exporter.metrics", false, "Whether to use the cloud cost exporter metrics")
 	flag.Parse()
 
 	clusters := flag.Args()
 
 	ctx := context.Background()
-	if err := run(ctx, fromFile, toFile, prometheusAddress, httpConfigFile, reportType, username, password, clusters); err != nil {
+	if err := run(ctx, fromFile, toFile, prometheusAddress, httpConfigFile, reportType, username, password, clusters, useCloudCostExporterMetrics); err != nil {
 		fmt.Printf("Could not run: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportType, username, password string, clusters []string) error {
+func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportType, username, password string, clusters []string, useCloudCostExporterMetrics bool) error {
 	from, err := os.ReadFile(fromFile)
 	if err != nil {
 		return fmt.Errorf("could not read file: %s", err)
@@ -42,10 +44,11 @@ func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportT
 	}
 
 	client, err := costmodel.NewClient(&costmodel.ClientConfig{
-		Address:        address,
-		HTTPConfigFile: httpConfigFile,
-		Username:       username,
-		Password:       password,
+		Address:                     address,
+		HTTPConfigFile:              httpConfigFile,
+		Username:                    username,
+		Password:                    password,
+		UseCloudCostExporterMetrics: useCloudCostExporterMetrics,
 	})
 
 	if err != nil {

--- a/pkg/costmodel/client.go
+++ b/pkg/costmodel/client.go
@@ -32,6 +32,15 @@ avg by (spot) (node_cpu_hourly_cost{cluster="%s"}
            )
 )
 `
+	cloudcostExporterQueryCostPerCpu = `
+	avg by (price_tier) (
+		cloudcost_aws_ec2_instance_cpu_usd_per_core_hour{cluster_name="%s"}
+		or
+		cloudcost_azure_aks_instance_cpu_usd_per_core_hour{cluster_name="%s"}
+		or
+		cloudcost_gcp_gke_instance_cpu_usd_per_core_hour{cluster_name="%s"}
+)
+`
 
 	queryMemoryCost = `
 avg by (spot) (node_ram_hourly_cost{cluster="%s"}
@@ -47,6 +56,15 @@ avg by (spot) (node_ram_hourly_cost{cluster="%s"}
                  ,"spot", "false", "", ""
                )
            )
+)
+`
+	cloudcostExporterQueryMemoryCost = `
+	avg by (price_tier) (
+		cloudcost_aws_ec2_instance_memory_usd_per_gib_hour{cluster_name="%s"}
+		or
+		cloudcost_azure_aks_instance_memory_usd_per_gib_hour{cluster_name="%s"}
+		or
+		cloudcost_gcp_gke_instance_memory_usd_per_gib_hour{cluster_name="%s"}
 )
 `
 	queryPersistentVolumeCost = "avg_over_time(avg(pv_hourly_cost{cluster=\"%s\"})[24h:1m])"
@@ -70,7 +88,8 @@ var (
 
 // Client is a client for the cost model.
 type Client struct {
-	client api.Client
+	client                      api.Client
+	useCloudCostExporterMetrics bool
 }
 
 // Clients bundles the dev and prod client in one struct.
@@ -81,10 +100,11 @@ type Clients struct {
 
 // ClientConfig is the configuration for the cost model client.
 type ClientConfig struct {
-	Address        string
-	HTTPConfigFile string
-	Username       string
-	Password       string
+	Address                     string
+	HTTPConfigFile              string
+	Username                    string
+	Password                    string
+	UseCloudCostExporterMetrics bool
 }
 
 // NewClient creates a new cost model client with the given configuration.
@@ -123,7 +143,10 @@ func NewClient(config *ClientConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Client{client: client}, nil
+	return &Client{
+		client:                      client,
+		useCloudCostExporterMetrics: config.UseCloudCostExporterMetrics,
+	}, nil
 }
 
 // NewClients creates a new cost model clients with the given configuration.
@@ -143,6 +166,10 @@ func NewClients(prodConfig, devConfig *ClientConfig) (*Clients, error) {
 // GetCostPerCPU returns the average cost per CPU for a given cluster.
 func (c *Client) GetCostPerCPU(ctx context.Context, cluster string) (Cost, error) {
 	query := fmt.Sprintf(queryCostPerCPU, cluster)
+	if c.useCloudCostExporterMetrics {
+		query = fmt.Sprintf(cloudcostExporterQueryCostPerCpu, cluster, cluster, cluster)
+	}
+	fmt.Printf("query: %s\n", query)
 	results, err := c.query(ctx, query)
 	if err != nil {
 		return Cost{}, err
@@ -153,6 +180,9 @@ func (c *Client) GetCostPerCPU(ctx context.Context, cluster string) (Cost, error
 // GetMemoryCost returns the cost per memory for a given cluster
 func (c *Client) GetMemoryCost(ctx context.Context, cluster string) (Cost, error) {
 	query := fmt.Sprintf(queryMemoryCost, cluster)
+	if c.useCloudCostExporterMetrics {
+		query = fmt.Sprintf(cloudcostExporterQueryMemoryCost, cluster, cluster, cluster)
+	}
 	results, err := c.query(ctx, query)
 	if err != nil {
 		return Cost{}, err
@@ -202,6 +232,17 @@ func (c *Client) parseResults(results model.Value) (Cost, error) {
 			cost.Spot = value
 		case "false":
 			cost.NonSpot = value
+		default:
+			// This is when there is no spot/non-spot label
+			cost.Dollars = value
+		}
+		// Handles the case for cloudcost exporter metrics where `price_tier` is the label for spot/non-spot
+		// TODO: Delete after removing support for OpenCost
+		switch sample.Metric["price_tier"] {
+		case "ondemand":
+			cost.NonSpot = value
+		case "spot":
+			cost.Spot = value
 		default:
 			// This is when there is no spot/non-spot label
 			cost.Dollars = value


### PR DESCRIPTION
First attempt at trying to migrate to using cloudcost-exporter metrics. Took a naive approach of adding a config to toggle cloudcost-exporter metrics. Added three new queries for cloudcost-exporter to get the avg cost of
- Cpu cores
- Memory (GiB)
- Persistent Volumes

Discovered that cloudcost-exporter does not implement cost of persistent storage(see https://github.com/grafana/cloudcost-exporter/issues/236).

To test out, follow the setup guide and run the estimator command:

```shell
go run ./cmd/estimator/ \
  -from $PWD/pkg/costmodel/testdata/resource/Deployment.json \
  -to $PWD/pkg/costmodel/testdata/resource/Deployment-more-requests.json \
  -http.config.file ~/.config/dev.yaml \
  -prometheus.address $PROMETHEUS_ADDRESS \
   dev-us-east-0

```

Since this releases the change behind a flag, we can merge this whenever we're comfortable and enable it when we're comfortable. 

- relates #29