### PR TITLE
Add useragent to headers

### DIFF
--- a/pkg/costmodel/client.go
+++ b/pkg/costmodel/client.go
@@ -135,7 +135,7 @@ func NewClient(config *ClientConfig) (*Client, error) {
 		fmt.Println("HTTP config file and basic auth not provided, using no authentication")
 	}
 
-	roundTripper, err := configutil.NewRoundTripperFromConfig(*cfg, "grafana-kost-estimator", configutil.WithHTTP2Disabled())
+	roundTripper, err := configutil.NewRoundTripperFromConfig(*cfg, "grafana-kost-estimator", configutil.WithHTTP2Disabled(), configutil.WithUserAgent("grafana-kost-estimator"))
 	if err != nil {
 		return nil, fmt.Errorf("error creating round tripper: %v", err)
 	}


### PR DESCRIPTION
This adds a configuration option for the RoundTripper that sets the useragent to `grafana-kost-estimator`. This helps downstream Prometheus instances understand where the queries that are coming from. If the logs are captured by something such as loki, you can easily filter our queries sent to Prometheus by the kost bot.