### PR TITLE
Add query to calculate cost of PV change with CloudCost exporter metrics

### DIFF
--- a/pkg/costmodel/testdata/resource/StatefulSet-more-storage.json
+++ b/pkg/costmodel/testdata/resource/StatefulSet-more-storage.json
@@ -1,0 +1,147 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": {
+        "creationTimestamp": "2022-10-05T20:38:31Z",
+        "generation": 17,
+        "labels": {
+            "kustomize.toolkit.fluxcd.io/name": "kube-manifests-opencost",
+            "kustomize.toolkit.fluxcd.io/namespace": "opencost",
+            "tanka.dev/environment": "85ead74422d749cb54711e74c81bc5d6ed6da54e92b5fa69"
+        },
+        "name": "opencost",
+        "namespace": "opencost",
+        "resourceVersion": "2386985939",
+        "uid": "56495ef8-2650-46e8-9528-28759cf47151"
+    },
+    "spec": {
+        "podManagementPolicy": "OrderedReady",
+        "replicas": 1,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "name": "opencost"
+            }
+        },
+        "serviceName": "opencost",
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "name": "opencost"
+                }
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "preference": {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "cloud.google.com/gke-spot",
+                                            "operator": "In",
+                                            "values": [
+                                                "true"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "weight": 100
+                            }
+                        ]
+                    }
+                },
+                "containers": [
+                    {
+                        "env": [
+                        ],
+                        "image": "quay.io/kubecost1/kubecost-cost-model:prod-1.100.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "opencost",
+                        "ports": [
+                            {
+                                "containerPort": 9003,
+                                "name": "http-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "4",
+                                "memory": "8Gi"
+                            },
+                            "requests": {
+                                "cpu": "1",
+                                "memory": "4Gi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/configs",
+                                "name": "opencost-data"
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 10001
+                },
+                "serviceAccount": "opencost",
+                "serviceAccountName": "opencost",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "type",
+                        "operator": "Equal",
+                        "value": "spot-node"
+                    }
+                ]
+            }
+        },
+        "updateStrategy": {
+            "type": "RollingUpdate"
+        },
+        "volumeClaimTemplates": [
+            {
+                "apiVersion": "v1",
+                "kind": "PersistentVolumeClaim",
+                "metadata": {
+                    "creationTimestamp": null,
+                    "name": "opencost-data"
+                },
+                "spec": {
+                    "accessModes": [
+                        "ReadWriteOnce"
+                    ],
+                    "resources": {
+                        "requests": {
+                            "storage": "320Gi"
+                        }
+                    },
+                    "volumeMode": "Filesystem"
+                },
+                "status": {
+                    "phase": "Pending"
+                }
+            }
+        ]
+    },
+    "status": {
+        "availableReplicas": 1,
+        "collisionCount": 0,
+        "currentReplicas": 1,
+        "currentRevision": "opencost-6666f8bdb7",
+        "observedGeneration": 17,
+        "readyReplicas": 1,
+        "replicas": 1,
+        "updateRevision": "opencost-6666f8bdb7",
+        "updatedReplicas": 1
+    }
+}


### PR DESCRIPTION
This ones a bit more of a challenge then CPU/Memory, due to three problems:
1. Cloudcost exporter does not emit metrics for persistent volumes for Azure(https://github.com/grafana/cloudcost-exporter/issues/236)
2. AWS ebs cost metrics does not have a cluster label(https://github.com/grafana/cloudcost-exporter/issues/450)
3. persisent volumes in GKE and EKS emit the total hourly cost of the volume, _not_ the hourly cost per GiB

I utilized Prometheus or ooperator(https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators) to overcome not having Azure pv costs. Effectively the query will attempt to find the average cost of pvs for
1. eks volumes via CloudCost Exporter
2. gke volumes via CloudCost Exporter
3. azure volumes via OpenCost

This works because we're only querying one cluster at a time _by name_, and we rely upon the fact that cluster names are unique within Grafana Labs infrastructure.

The missing cluster label for eks cost metrics and persistent volumes not having cluster labels can be overcome by utilizing `kube_persistentvolume_capacity_bytes` metrics emitted by kube-state-metrics.

This was tested by looking at an EKS cluster like so:

```shell
go run ./cmd/estimator/ \
  -use.cloud.cost.exporter.metrics=true -from $PWD/pkg/costmodel/testdata/resource/StatefulSet.json \
  -to $PWD/pkg/costmodel/testdata/resource/StatefulSet-more-storage.json \
  -http.config.file ~/.config/dev.yaml \
  -prometheus.address $PROMETHEUS_ADDRESS \
   dev-us-east-0
```

- relates to #29