### PR TITLE
Remove all references to OpenCost

### DIFF
--- a/cmd/bot/config.go
+++ b/cmd/bot/config.go
@@ -31,11 +31,10 @@ type config struct {
 
 	GitHub github.Config
 
-	IsCI                        bool   `envconfig:"CI"`
-	PR                          int    `envconfig:"GITHUB_PULL_REQUEST" required:"true"`
-	Event                       string `envconfig:"GITHUB_EVENT_NAME"`
-	LogLevel                    string `envconfig:"LOG_LEVEL" default:"info"`
-	UseCloudCostExporterMetrics bool   `envconfig:"USE_CLOUD_COST_EXPORTER" default:"false"`
+	IsCI     bool   `envconfig:"CI"`
+	PR       int    `envconfig:"GITHUB_PULL_REQUEST" required:"true"`
+	Event    string `envconfig:"GITHUB_EVENT_NAME"`
+	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
 }
 
 const pullRequestEvent = "pull_request"

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -56,18 +56,16 @@ func realMain(ctx context.Context) error {
 
 	prometheusClients, err := costmodel.NewClients(
 		&costmodel.ClientConfig{
-			Address:                     cfg.Prometheus.Prod.Address,
-			HTTPConfigFile:              cfg.Prometheus.Prod.HTTPConfigFile,
-			Username:                    cfg.Prometheus.Prod.Username,
-			Password:                    cfg.Prometheus.Prod.Password,
-			UseCloudCostExporterMetrics: cfg.UseCloudCostExporterMetrics,
+			Address:        cfg.Prometheus.Prod.Address,
+			HTTPConfigFile: cfg.Prometheus.Prod.HTTPConfigFile,
+			Username:       cfg.Prometheus.Prod.Username,
+			Password:       cfg.Prometheus.Prod.Password,
 		},
 		&costmodel.ClientConfig{
-			Address:                     cfg.Prometheus.Dev.Address,
-			HTTPConfigFile:              cfg.Prometheus.Dev.HTTPConfigFile,
-			Username:                    cfg.Prometheus.Dev.Username,
-			Password:                    cfg.Prometheus.Dev.Password,
-			UseCloudCostExporterMetrics: cfg.UseCloudCostExporterMetrics,
+			Address:        cfg.Prometheus.Dev.Address,
+			HTTPConfigFile: cfg.Prometheus.Dev.HTTPConfigFile,
+			Username:       cfg.Prometheus.Dev.Username,
+			Password:       cfg.Prometheus.Dev.Password,
 		})
 	if err != nil {
 		return fmt.Errorf("creating cost model client: %w", err)

--- a/cmd/estimator/main.go
+++ b/cmd/estimator/main.go
@@ -11,7 +11,6 @@ import (
 
 func main() {
 	var fromFile, toFile, prometheusAddress, httpConfigFile, reportType, username, password string
-	var useCloudCostExporterMetrics bool
 	flag.StringVar(&fromFile, "from", "", "The file to compare from")
 	flag.StringVar(&toFile, "to", "", "The file to compare to")
 	flag.StringVar(&prometheusAddress, "prometheus.address", "http://localhost:9093/prometheus", "The Address of the prometheus server")
@@ -19,19 +18,18 @@ func main() {
 	flag.StringVar(&username, "username", "", "Mimir username")
 	flag.StringVar(&password, "password", "", "Mimir password")
 	flag.StringVar(&reportType, "report.type", "table", "The type of report to generate. Options are: table, summary")
-	flag.BoolVar(&useCloudCostExporterMetrics, "use.cloud.cost.exporter.metrics", false, "Whether to use the cloud cost exporter metrics")
 	flag.Parse()
 
 	clusters := flag.Args()
 
 	ctx := context.Background()
-	if err := run(ctx, fromFile, toFile, prometheusAddress, httpConfigFile, reportType, username, password, clusters, useCloudCostExporterMetrics); err != nil {
+	if err := run(ctx, fromFile, toFile, prometheusAddress, httpConfigFile, reportType, username, password, clusters); err != nil {
 		fmt.Printf("Could not run: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportType, username, password string, clusters []string, useCloudCostExporterMetrics bool) error {
+func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportType, username, password string, clusters []string) error {
 	from, err := os.ReadFile(fromFile)
 	if err != nil {
 		return fmt.Errorf("could not read file: %s", err)
@@ -44,11 +42,10 @@ func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportT
 	}
 
 	client, err := costmodel.NewClient(&costmodel.ClientConfig{
-		Address:                     address,
-		HTTPConfigFile:              httpConfigFile,
-		Username:                    username,
-		Password:                    password,
-		UseCloudCostExporterMetrics: useCloudCostExporterMetrics,
+		Address:        address,
+		HTTPConfigFile: httpConfigFile,
+		Username:       username,
+		Password:       password,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Now that the v0.0.5 has been tested out in production, we can remove all references to OpenCost.

This removes the flags, configuration, and branches in the codebase. There is still one query that references OpenCost, but that can be removed in a future patch once cloudcost-exporter emits Azure persistent volume costs.