### PR TITLE
Feat/cost reports for hpa

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -158,7 +158,7 @@ func realMain(ctx context.Context) error {
 			return fmt.Errorf("added manifests: %w", err)
 		}
 
-		reporter.AddReport(cost, costmodel.Requirements{}, req)
+		reporter.AddReportWithResolvedReplicas(ctx, prometheusClients, cost, costmodel.Requirements{}, req)
 	}
 	slog.Info("Finished processing added files", "count", len(cf.Added), "duration", time.Since(start))
 
@@ -173,7 +173,7 @@ func realMain(ctx context.Context) error {
 			return fmt.Errorf("deleted manifest: %w", err)
 		}
 
-		reporter.AddReport(cost, req, costmodel.Requirements{})
+		reporter.AddReportWithResolvedReplicas(ctx, prometheusClients, cost, req, costmodel.Requirements{})
 	}
 	slog.Info("Finished processing deleted files", "count", len(cf.Deleted), "duration", time.Since(start))
 
@@ -195,7 +195,7 @@ func realMain(ctx context.Context) error {
 			return fmt.Errorf("new manifest: %w", err)
 		}
 
-		reporter.AddReport(cost, from, to)
+		reporter.AddReportWithResolvedReplicas(ctx, prometheusClients, cost, from, to)
 	}
 	slog.Info("Finished processing modified files", "count", len(cf.Modified), "duration", time.Since(start))
 
@@ -218,7 +218,7 @@ func realMain(ctx context.Context) error {
 			return fmt.Errorf("manifest after renaming: %w", err)
 		}
 
-		reporter.AddReport(cost, from, to)
+		reporter.AddReportWithResolvedReplicas(ctx, prometheusClients, cost, from, to)
 	}
 	slog.Info("Finished processing renamed files", "count", len(cf.Renamed), "duration", time.Since(start))
 

--- a/cmd/estimator/main.go
+++ b/cmd/estimator/main.go
@@ -69,7 +69,7 @@ func run(ctx context.Context, fromFile, toFile, address, httpConfigFile, reportT
 		if err != nil {
 			return fmt.Errorf("could not parse manifest file(%s): %s", toFile, err)
 		}
-		reporter.AddReport(cost, fromRequests, toRequests)
+		reporter.AddReportWithResolvedReplicas(ctx, client, cost, fromRequests, toRequests)
 	}
 
 	return reporter.Write()

--- a/pkg/costmodel/client.go
+++ b/pkg/costmodel/client.go
@@ -61,16 +61,21 @@ const (
 			sum(nodepool:node:sum{cluster="%s"})[30d:1d]
 		)
 	`
+
+	// queryHPATargeting filters kube_horizontalpodautoscaler_info by the workload it targets.
+	// The horizontalpodautoscaler label on a hit holds the HPA name (also used by KEDA-managed HPAs).
+	queryHPATargeting = `kube_horizontalpodautoscaler_info{cluster="%s", namespace="%s", scaletargetref_kind="%s", scaletargetref_name="%s"}`
 )
 
 // ErrNoResults is the error returned when querying for costs returns
 // no results.
 var (
-	ErrNoResults         = errors.New("no cost results")
-	ErrBadQuery          = errors.New("bad query")
-	ErrNilConfig         = errors.New("client config is nil")
-	ErrEmptyAddress      = errors.New("client address can't be empty")
-	ErrProdConfigMissing = errors.New("prod config is missing")
+	ErrNoResults          = errors.New("no cost results")
+	ErrBadQuery           = errors.New("bad query")
+	ErrNilConfig          = errors.New("client config is nil")
+	ErrEmptyAddress       = errors.New("client address can't be empty")
+	ErrProdConfigMissing  = errors.New("prod config is missing")
+	ErrHPADetectionFailed = errors.New("hpa detection failed")
 )
 
 // Client is a client for the cost model.
@@ -181,6 +186,31 @@ func (c *Client) GetNodeCount(ctx context.Context, cluster string) (int, error) 
 	}
 
 	return int(result[0].Value), nil
+}
+
+// HPATargeting returns the name of the HorizontalPodAutoscaler targeting the given
+// (cluster, namespace, kind, name) workload, or an empty string if no HPA targets it.
+// Works for vanilla HPAs and KEDA-managed HPAs (KEDA creates a regular HPA underneath).
+// Transport or unexpected response shape errors are wrapped with ErrHPADetectionFailed
+// so callers can distinguish "definitely not HPA-managed" from "we couldn't tell."
+func (c *Client) HPATargeting(ctx context.Context, cluster, namespace, kind, name string) (string, error) {
+	query := fmt.Sprintf(queryHPATargeting, cluster, namespace, kind, name)
+	results, err := c.query(ctx, query)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrHPADetectionFailed, err)
+	}
+	vec, ok := results.(model.Vector)
+	if !ok {
+		return "", fmt.Errorf("%w: unexpected result type %T", ErrHPADetectionFailed, results)
+	}
+	if len(vec) == 0 {
+		return "", nil
+	}
+	hpa := string(vec[0].Metric["horizontalpodautoscaler"])
+	if hpa == "" {
+		return "", fmt.Errorf("%w: missing horizontalpodautoscaler label", ErrHPADetectionFailed)
+	}
+	return hpa, nil
 }
 
 // GetCostForPersistentVolume returns the average cost per persistent volume for a given cluster

--- a/pkg/costmodel/client.go
+++ b/pkg/costmodel/client.go
@@ -65,6 +65,10 @@ const (
 	// queryHPATargeting filters kube_horizontalpodautoscaler_info by the workload it targets.
 	// The horizontalpodautoscaler label on a hit holds the HPA name (also used by KEDA-managed HPAs).
 	queryHPATargeting = `kube_horizontalpodautoscaler_info{cluster="%s", namespace="%s", scaletargetref_kind="%s", scaletargetref_name="%s"}`
+
+	// queryObservedReplicas reports the average actual replica count over a 7d window.
+	// Format args: metric, cluster, namespace, kindLabel, name.
+	queryObservedReplicas = `avg(avg_over_time(%s{cluster="%s", namespace="%s", %s="%s"}[7d]))`
 )
 
 // ErrNoResults is the error returned when querying for costs returns
@@ -76,6 +80,7 @@ var (
 	ErrEmptyAddress       = errors.New("client address can't be empty")
 	ErrProdConfigMissing  = errors.New("prod config is missing")
 	ErrHPADetectionFailed = errors.New("hpa detection failed")
+	ErrUnsupportedKind    = errors.New("unsupported workload kind")
 )
 
 // Client is a client for the cost model.
@@ -186,6 +191,45 @@ func (c *Client) GetNodeCount(ctx context.Context, cluster string) (int, error) 
 	}
 
 	return int(result[0].Value), nil
+}
+
+// GetObservedReplicas returns the 7-day average replica count for the given workload
+// from kube-state-metrics, regardless of who scales it (HPA, KEDA, manual). Used to
+// substitute manifest replicas with reality for HPA-managed workloads.
+// Returns ErrUnsupportedKind for kinds without a replica-count metric (DaemonSet, Pod, Job).
+// Returns ErrNoResults if the query succeeds but has no samples (e.g., brand-new workload
+// with no history) — callers should surface this rather than silently fall back.
+func (c *Client) GetObservedReplicas(ctx context.Context, cluster, namespace, kind, name string) (float64, error) {
+	metric, kindLabel, err := replicaMetricForKind(kind)
+	if err != nil {
+		return 0, err
+	}
+	query := fmt.Sprintf(queryObservedReplicas, metric, cluster, namespace, kindLabel, name)
+	results, err := c.query(ctx, query)
+	if err != nil {
+		return 0, ErrBadQuery
+	}
+	vec, ok := results.(model.Vector)
+	if !ok {
+		return 0, ErrBadQuery
+	}
+	if len(vec) == 0 {
+		return 0, ErrNoResults
+	}
+	return float64(vec[0].Value), nil
+}
+
+// replicaMetricForKind returns the kube-state-metrics metric name and the label
+// holding the workload name for a given Kubernetes kind.
+func replicaMetricForKind(kind string) (metric, label string, err error) {
+	switch kind {
+	case "Deployment":
+		return "kube_deployment_status_replicas", "deployment", nil
+	case "StatefulSet":
+		return "kube_statefulset_replicas", "statefulset", nil
+	default:
+		return "", "", fmt.Errorf("%w: %s", ErrUnsupportedKind, kind)
+	}
 }
 
 // HPATargeting returns the name of the HorizontalPodAutoscaler targeting the given

--- a/pkg/costmodel/client.go
+++ b/pkg/costmodel/client.go
@@ -325,17 +325,28 @@ func (c *Clients) GetClusterCosts(ctx context.Context, cluster string) (*CostMod
 	defer func() {
 		slog.Info("GetClusterCosts", "cluster", cluster, "duration", time.Since(start))
 	}()
-	var cost *CostModel
-	var err error
-	// if dev client is present
-	client := c.Prod
-	if c.Dev != nil && strings.HasPrefix(cluster, "dev-") {
-		client = c.Dev
-	}
-	cost, err = GetCostModelForCluster(ctx, client, cluster)
+	cost, err := GetCostModelForCluster(ctx, c.clientFor(cluster), cluster)
 	if err != nil {
 		// TODO here we should probably return an error like below
 		return nil, fmt.Errorf("fetching cost model for cluster %s: %w", cluster, err)
 	}
 	return cost, nil
+}
+
+// clientFor picks the prod or dev client based on cluster name prefix.
+func (c *Clients) clientFor(cluster string) *Client {
+	if c.Dev != nil && strings.HasPrefix(cluster, "dev-") {
+		return c.Dev
+	}
+	return c.Prod
+}
+
+// HPATargeting routes to the appropriate prod/dev client based on cluster prefix.
+func (c *Clients) HPATargeting(ctx context.Context, cluster, namespace, kind, name string) (string, error) {
+	return c.clientFor(cluster).HPATargeting(ctx, cluster, namespace, kind, name)
+}
+
+// GetObservedReplicas routes to the appropriate prod/dev client based on cluster prefix.
+func (c *Clients) GetObservedReplicas(ctx context.Context, cluster, namespace, kind, name string) (float64, error) {
+	return c.clientFor(cluster).GetObservedReplicas(ctx, cluster, namespace, kind, name)
 }

--- a/pkg/costmodel/client_test.go
+++ b/pkg/costmodel/client_test.go
@@ -483,3 +483,120 @@ func TestClient_HPATargeting(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_GetObservedReplicas(t *testing.T) {
+	type Result struct {
+		Metric model.Metric     `json:"metric"`
+		Value  model.SamplePair `json:"value"`
+	}
+	type mockResponse struct {
+		Status string `json:"status"`
+		Data   struct {
+			Type   string   `json:"resultType"`
+			Result []Result `json:"result"`
+		} `json:"data"`
+	}
+
+	mkVector := func(v model.SampleValue) *mockResponse {
+		return &mockResponse{
+			Status: "success",
+			Data: struct {
+				Type   string   `json:"resultType"`
+				Result []Result `json:"result"`
+			}{
+				Type: "vector",
+				Result: []Result{
+					{
+						Metric: model.Metric{},
+						Value:  model.SamplePair{Timestamp: model.TimeFromUnix(0), Value: v},
+					},
+				},
+			},
+		}
+	}
+	emptyVector := &mockResponse{
+		Status: "success",
+		Data: struct {
+			Type   string   `json:"resultType"`
+			Result []Result `json:"result"`
+		}{Type: "vector", Result: []Result{}},
+	}
+
+	tests := []struct {
+		name        string
+		kind        string
+		response    *mockResponse
+		statusCode  int
+		want        float64
+		wantErrIs   error
+		wantErrNone bool
+	}{
+		{
+			name:        "Deployment hit returns observed avg",
+			kind:        "Deployment",
+			response:    mkVector(878.2),
+			want:        878.2,
+			wantErrNone: true,
+		},
+		{
+			name:        "StatefulSet hit returns observed avg",
+			kind:        "StatefulSet",
+			response:    mkVector(50.0),
+			want:        50.0,
+			wantErrNone: true,
+		},
+		{
+			name:      "empty vector returns ErrNoResults",
+			kind:      "Deployment",
+			response:  emptyVector,
+			want:      0,
+			wantErrIs: ErrNoResults,
+		},
+		{
+			name:      "unsupported kind returns error without querying",
+			kind:      "DaemonSet",
+			want:      0,
+			wantErrIs: ErrUnsupportedKind,
+		},
+		{
+			name:       "HTTP 500 returns ErrBadQuery",
+			kind:       "Deployment",
+			statusCode: http.StatusInternalServerError,
+			want:       0,
+			wantErrIs:  ErrBadQuery,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.statusCode != 0 {
+					w.WriteHeader(tt.statusCode)
+					return
+				}
+				if err := json.NewEncoder(w).Encode(tt.response); err != nil {
+					t.Errorf("error encoding response: %v", err)
+					return
+				}
+			}))
+			defer svr.Close()
+
+			c, err := NewClient(&ClientConfig{Address: svr.URL})
+			if err != nil {
+				t.Fatalf("creating client: %v", err)
+			}
+
+			got, err := c.GetObservedReplicas(context.Background(), "c", "ns", tt.kind, "foo")
+			if tt.wantErrNone {
+				if err != nil {
+					t.Fatalf("GetObservedReplicas() unexpected error: %v", err)
+				}
+			} else if !errors.Is(err, tt.wantErrIs) {
+				t.Fatalf("GetObservedReplicas() error = %v, want errors.Is %v", err, tt.wantErrIs)
+			}
+			if got != tt.want {
+				t.Errorf("GetObservedReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/costmodel/client_test.go
+++ b/pkg/costmodel/client_test.go
@@ -378,3 +378,108 @@ func TestClient_GetNodeCount(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_HPATargeting(t *testing.T) {
+	type Result struct {
+		Metric model.Metric     `json:"metric"`
+		Value  model.SamplePair `json:"value"`
+	}
+	type mockResponse struct {
+		Status string `json:"status"`
+		Data   struct {
+			Type   string   `json:"resultType"`
+			Result []Result `json:"result"`
+		} `json:"data"`
+	}
+
+	tests := []struct {
+		name        string
+		response    *mockResponse
+		statusCode  int
+		want        string
+		wantErrIs   error
+		wantErrNone bool
+	}{
+		{
+			name: "vector hit returns HPA name",
+			response: &mockResponse{
+				Status: "success",
+				Data: struct {
+					Type   string   `json:"resultType"`
+					Result []Result `json:"result"`
+				}{
+					Type: "vector",
+					Result: []Result{
+						{
+							Metric: model.Metric{
+								"horizontalpodautoscaler":    "keda-hpa-foo",
+								"scaletargetref_kind":        "Deployment",
+								"scaletargetref_name":        "foo",
+								"scaletargetref_api_version": "apps/v1",
+								"namespace":                  "ns",
+								"cluster":                    "c",
+							},
+							Value: model.SamplePair{Timestamp: model.TimeFromUnix(0), Value: 1},
+						},
+					},
+				},
+			},
+			want:        "keda-hpa-foo",
+			wantErrNone: true,
+		},
+		{
+			name: "empty vector returns empty string and no error",
+			response: &mockResponse{
+				Status: "success",
+				Data: struct {
+					Type   string   `json:"resultType"`
+					Result []Result `json:"result"`
+				}{
+					Type:   "vector",
+					Result: []Result{},
+				},
+			},
+			want:        "",
+			wantErrNone: true,
+		},
+		{
+			name:       "HTTP 500 wraps ErrHPADetectionFailed",
+			statusCode: http.StatusInternalServerError,
+			want:       "",
+			wantErrIs:  ErrHPADetectionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.statusCode != 0 {
+					w.WriteHeader(tt.statusCode)
+					return
+				}
+				if err := json.NewEncoder(w).Encode(tt.response); err != nil {
+					t.Errorf("error encoding response: %v", err)
+					return
+				}
+			}))
+			defer svr.Close()
+
+			c, err := NewClient(&ClientConfig{Address: svr.URL})
+			if err != nil {
+				t.Fatalf("creating client: %v", err)
+			}
+
+			got, err := c.HPATargeting(context.Background(), "c", "ns", "Deployment", "foo")
+			if tt.wantErrNone {
+				if err != nil {
+					t.Fatalf("HPATargeting() unexpected error: %v", err)
+				}
+			} else if !errors.Is(err, tt.wantErrIs) {
+				t.Fatalf("HPATargeting() error = %v, want errors.Is %v", err, tt.wantErrIs)
+			}
+			if got != tt.want {
+				t.Errorf("HPATargeting() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -127,8 +127,8 @@ func GetCostModelForCluster(ctx context.Context, client *Client, cluster string)
 
 // TotalCostForPeriod calculates the costs of each resource on the CostModel and returns the sum of the costs
 func (c *CostModel) TotalCostForPeriod(p Period, r Requirements) float64 {
-	cpuCost := c.CPU.NonSpotCPUForPeriod(p, r.CPU)
-	ramCost := c.RAM.NonSpotMemoryForPeriod(p, r.Memory)
-	pvCost := c.PersistentVolume.DollarsForPeriod(p, r.PersistentVolume)
+	cpuCost := c.CPU.NonSpotCPUForPeriod(p, r.TotalCPU())
+	ramCost := c.RAM.NonSpotMemoryForPeriod(p, r.TotalMemory())
+	pvCost := c.PersistentVolume.DollarsForPeriod(p, r.TotalPersistentVolume())
 	return cpuCost + ramCost + pvCost
 }

--- a/pkg/costmodel/markdown_reporter.go
+++ b/pkg/costmodel/markdown_reporter.go
@@ -23,9 +23,9 @@ func (c resourcesCost) Total() float64 {
 
 func resourcesCosts(m *CostModel, req Requirements) resourcesCost {
 	return resourcesCost{
-		CPU:       m.CPU.NonSpotCPUForPeriod(Monthly, req.CPU),
-		Memory:    m.RAM.NonSpotMemoryForPeriod(Monthly, req.Memory),
-		Storage:   m.PersistentVolume.DollarsForPeriod(Monthly, req.PersistentVolume),
+		CPU:       m.CPU.NonSpotCPUForPeriod(Monthly, req.TotalCPU()),
+		Memory:    m.RAM.NonSpotMemoryForPeriod(Monthly, req.TotalMemory()),
+		Storage:   m.PersistentVolume.DollarsForPeriod(Monthly, req.TotalPersistentVolume()),
 		Kind:      req.Kind,
 		Namespace: req.Namespace,
 		Name:      req.Name,

--- a/pkg/costmodel/markdown_reporter.go
+++ b/pkg/costmodel/markdown_reporter.go
@@ -137,8 +137,10 @@ var tpl = template.Must(template.New("").Funcs(templateFuncs).Parse(commentTempl
 // writeMarkdown
 func (r *Reporter) writeMarkdown() error {
 	d := templateData{
-		Reports: make(map[string]costReports),
-		Summary: make(map[string]summaryReport),
+		Reports:  make(map[string]costReports),
+		Summary:  make(map[string]summaryReport),
+		Warnings: append([]string(nil), r.warnings...),
+		Errors:   append([]string(nil), r.errors...),
 	}
 
 	for _, r := range r.reports {

--- a/pkg/costmodel/markdown_reporter_test.go
+++ b/pkg/costmodel/markdown_reporter_test.go
@@ -34,9 +34,10 @@ func TestResourcesCosts(t *testing.T) {
 	}
 
 	req := Requirements{
-		CPU:              h.cpu("100m"),
-		Memory:           h.mem("2Gi"),
-		PersistentVolume: h.pv("4Gi"),
+		CPUPerPod:              h.cpu("100m"),
+		MemoryPerPod:           h.mem("2Gi"),
+		PersistentVolumePerPod: h.pv("4Gi"),
+		Replicas:               1,
 	}
 
 	got := resourcesCosts(cm, req)
@@ -177,14 +178,16 @@ func TestTemplate(t *testing.T) {
 	}
 
 	req1 := Requirements{
-		CPU:              h.cpu("500m"),
-		Memory:           h.mem("2Gi"),
-		PersistentVolume: h.pv("4Gi"),
+		CPUPerPod:              h.cpu("500m"),
+		MemoryPerPod:           h.mem("2Gi"),
+		PersistentVolumePerPod: h.pv("4Gi"),
+		Replicas:               1,
 	}
 	req2 := Requirements{
-		CPU:              h.cpu("1"),
-		Memory:           h.mem("4Gi"),
-		PersistentVolume: h.pv("8Gi"),
+		CPUPerPod:              h.cpu("1"),
+		MemoryPerPod:           h.mem("4Gi"),
+		PersistentVolumePerPod: h.pv("8Gi"),
+		Replicas:               1,
 	}
 
 	tests := map[string]struct {

--- a/pkg/costmodel/replicas.go
+++ b/pkg/costmodel/replicas.go
@@ -1,0 +1,48 @@
+package costmodel
+
+import (
+	"context"
+	"math"
+)
+
+// ReplicaSource describes which signal ResolveReplicas used.
+type ReplicaSource int
+
+const (
+	// SourceManifest indicates the manifest's spec.replicas was authoritative
+	// (no HPA targets the workload).
+	SourceManifest ReplicaSource = iota
+	// SourceObservedHPA indicates an HPA targets the workload and the manifest
+	// replicas were replaced with the observed average from kube-state-metrics.
+	SourceObservedHPA
+)
+
+// HPAResolver is the subset of *Client behavior ResolveReplicas needs.
+// Lets policy be tested without httptest.
+type HPAResolver interface {
+	HPATargeting(ctx context.Context, cluster, namespace, kind, name string) (string, error)
+	GetObservedReplicas(ctx context.Context, cluster, namespace, kind, name string) (float64, error)
+}
+
+var _ HPAResolver = (*Client)(nil)
+
+// ResolveReplicas decides the right replica count for a workload at PR-cost-estimation time.
+// If no HPA targets the workload, the manifest count is authoritative.
+// If an HPA is detected, the observed 7d-average from kube-state-metrics is substituted
+// (rounded to nearest int) — manifest replicas are a lie under HPA control.
+// Errors from either query are returned so the caller can surface them rather than
+// silently fall back to a wrong number.
+func ResolveReplicas(ctx context.Context, r HPAResolver, cluster, namespace, kind, name string, manifestReplicas int) (int, ReplicaSource, error) {
+	hpa, err := r.HPATargeting(ctx, cluster, namespace, kind, name)
+	if err != nil {
+		return 0, SourceManifest, err
+	}
+	if hpa == "" {
+		return manifestReplicas, SourceManifest, nil
+	}
+	observed, err := r.GetObservedReplicas(ctx, cluster, namespace, kind, name)
+	if err != nil {
+		return 0, SourceObservedHPA, err
+	}
+	return int(math.Round(observed)), SourceObservedHPA, nil
+}

--- a/pkg/costmodel/replicas.go
+++ b/pkg/costmodel/replicas.go
@@ -24,7 +24,10 @@ type HPAResolver interface {
 	GetObservedReplicas(ctx context.Context, cluster, namespace, kind, name string) (float64, error)
 }
 
-var _ HPAResolver = (*Client)(nil)
+var (
+	_ HPAResolver = (*Client)(nil)
+	_ HPAResolver = (*Clients)(nil)
+)
 
 // ResolveReplicas decides the right replica count for a workload at PR-cost-estimation time.
 // If no HPA targets the workload, the manifest count is authoritative.

--- a/pkg/costmodel/replicas_test.go
+++ b/pkg/costmodel/replicas_test.go
@@ -1,0 +1,107 @@
+package costmodel
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeResolver struct {
+	hpaName     string
+	hpaErr      error
+	observed    float64
+	observedErr error
+
+	hpaCalls      int
+	observedCalls int
+}
+
+func (f *fakeResolver) HPATargeting(_ context.Context, _, _, _, _ string) (string, error) {
+	f.hpaCalls++
+	return f.hpaName, f.hpaErr
+}
+
+func (f *fakeResolver) GetObservedReplicas(_ context.Context, _, _, _, _ string) (float64, error) {
+	f.observedCalls++
+	return f.observed, f.observedErr
+}
+
+func TestResolveReplicas(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no HPA returns manifest replicas", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: ""}
+		got, src, err := ResolveReplicas(ctx, fr, "c", "ns", "Deployment", "foo", 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 3 {
+			t.Errorf("got replicas %d, want 3", got)
+		}
+		if src != SourceManifest {
+			t.Errorf("got source %v, want SourceManifest", src)
+		}
+		if fr.observedCalls != 0 {
+			t.Errorf("observed should not be queried when no HPA, got %d calls", fr.observedCalls)
+		}
+	})
+
+	t.Run("HPA managed substitutes observed and rounds", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: "keda-hpa-foo", observed: 878.6}
+		got, src, err := ResolveReplicas(ctx, fr, "c", "ns", "Deployment", "foo", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 879 {
+			t.Errorf("got replicas %d, want 879 (rounded from 878.6)", got)
+		}
+		if src != SourceObservedHPA {
+			t.Errorf("got source %v, want SourceObservedHPA", src)
+		}
+	})
+
+	t.Run("HPA detection error propagates without querying observed", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		fr := &fakeResolver{hpaErr: sentinel}
+		got, _, err := ResolveReplicas(ctx, fr, "c", "ns", "Deployment", "foo", 5)
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected error to wrap sentinel, got %v", err)
+		}
+		if got != 0 {
+			t.Errorf("got replicas %d, want 0 on error", got)
+		}
+		if fr.observedCalls != 0 {
+			t.Errorf("observed should not be queried on detection error, got %d calls", fr.observedCalls)
+		}
+	})
+
+	t.Run("HPA detected but observed empty returns ErrNoResults", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: "keda-hpa-foo", observedErr: ErrNoResults}
+		got, _, err := ResolveReplicas(ctx, fr, "c", "ns", "Deployment", "foo", 5)
+		if !errors.Is(err, ErrNoResults) {
+			t.Errorf("expected ErrNoResults, got %v", err)
+		}
+		if got != 0 {
+			t.Errorf("got replicas %d, want 0 on error", got)
+		}
+	})
+
+	t.Run("HPA detected and observed transport error propagates", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: "keda-hpa-foo", observedErr: ErrBadQuery}
+		_, _, err := ResolveReplicas(ctx, fr, "c", "ns", "Deployment", "foo", 5)
+		if !errors.Is(err, ErrBadQuery) {
+			t.Errorf("expected ErrBadQuery, got %v", err)
+		}
+	})
+
+	t.Run("rounds 0.5 up", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: "h", observed: 10.5}
+		got, _, err := ResolveReplicas(ctx, fr, "c", "ns", "Deployment", "foo", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 11 {
+			t.Errorf("got %d, want 11", got)
+		}
+	})
+}

--- a/pkg/costmodel/reporter.go
+++ b/pkg/costmodel/reporter.go
@@ -30,6 +30,8 @@ type Reporter struct {
 	Writer     io.Writer
 	reports    []report
 	reportType ReportType
+	warnings   []string
+	errors     []string
 }
 
 // report is a model for a cost report.
@@ -49,6 +51,19 @@ func (r *Reporter) AddReport(costModel *CostModel, from, to Requirements) {
 		From:      from,
 		To:        to,
 	})
+}
+
+// AddWarning records a non-fatal message that will be surfaced in the markdown
+// report under the Warnings section. Use for expected events or known limitations
+// (e.g., observed-replicas substitution applied for an HPA-managed workload).
+func (r *Reporter) AddWarning(msg string) {
+	r.warnings = append(r.warnings, msg)
+}
+
+// AddError records a message about an unexpected event that may have led to
+// inaccurate cost numbers. Surfaced under the Errors section in the markdown report.
+func (r *Reporter) AddError(msg string) {
+	r.errors = append(r.errors, msg)
 }
 
 func New(w io.Writer, reportType string) *Reporter {

--- a/pkg/costmodel/reporter.go
+++ b/pkg/costmodel/reporter.go
@@ -1,6 +1,7 @@
 package costmodel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -58,6 +59,56 @@ func (r *Reporter) AddReport(costModel *CostModel, from, to Requirements) {
 // (e.g., observed-replicas substitution applied for an HPA-managed workload).
 func (r *Reporter) AddWarning(msg string) {
 	r.warnings = append(r.warnings, msg)
+}
+
+// AddReportWithResolvedReplicas adds a cost report after substituting the manifest
+// replica count with the observed 7d-average for HPA-managed Deployment/StatefulSet
+// workloads. For unsupported kinds (DaemonSet, Pod, Job, CronJob) or when the
+// CostModel cannot be used to identify a cluster, falls back to AddReport with the
+// manifest replica count.
+//
+// On substitution, an audit-trail Warning is added to the reporter so reviewers can
+// see that observed replicas were used. On resolver errors, the manifest count is
+// preserved and an Error is added so misleading numbers are flagged rather than
+// silently presented.
+func (r *Reporter) AddReportWithResolvedReplicas(
+	ctx context.Context,
+	resolver HPAResolver,
+	cm *CostModel,
+	from, to Requirements,
+) {
+	id := to
+	if id.Kind == "" {
+		id = from
+	}
+	if cm == nil || cm.Cluster == nil || (id.Kind != "Deployment" && id.Kind != "StatefulSet") {
+		r.AddReport(cm, from, to)
+		return
+	}
+
+	replicas, source, err := ResolveReplicas(ctx, resolver, cm.Cluster.Name, id.Namespace, id.Kind, id.Name, id.Replicas)
+	if err != nil {
+		r.AddError(fmt.Sprintf("resolving replicas for %s/%s/%s on %s: %v",
+			id.Namespace, id.Kind, id.Name, cm.Cluster.Name, err))
+		r.AddReport(cm, from, to)
+		return
+	}
+
+	if source == SourceObservedHPA {
+		manifestReplicas := id.Replicas
+		if from.Kind != "" {
+			from.Replicas = replicas
+		}
+		if to.Kind != "" {
+			to.Replicas = replicas
+		}
+		r.AddWarning(fmt.Sprintf(
+			"used observed %d replicas (manifest: %d) for %s/%s/%s on %s — workload is HPA-managed",
+			replicas, manifestReplicas, id.Namespace, id.Kind, id.Name, cm.Cluster.Name,
+		))
+	}
+
+	r.AddReport(cm, from, to)
 }
 
 // AddError records a message about an unexpected event that may have led to

--- a/pkg/costmodel/reporter_test.go
+++ b/pkg/costmodel/reporter_test.go
@@ -256,3 +256,71 @@ func TestReporter_Write(t *testing.T) {
 		}
 	})
 }
+
+func TestReporter_AddWarning_AppearsInMarkdown(t *testing.T) {
+	cm := &CostModel{
+		Cluster:          &Cluster{Name: "test"},
+		CPU:              Cost{NonSpot: 1},
+		RAM:              Cost{NonSpot: 1},
+		PersistentVolume: Cost{NonSpot: 1},
+	}
+	req := Requirements{
+		CPUPerPod:    100,
+		MemoryPerPod: 1024 * 1024 * 1024,
+		Replicas:     1,
+		Kind:         "Deployment",
+		Namespace:    "ns",
+		Name:         "wk",
+	}
+
+	const msg = "HPA detection failed for ns/Deployment/wk: boom"
+	var s strings.Builder
+	r := New(&s, string(Markdown))
+	r.AddReport(cm, req, req)
+	r.AddWarning(msg)
+	if err := r.Write(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	got := s.String()
+	if !strings.Contains(got, ":warning: Warnings") {
+		t.Errorf("expected :warning: section in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, msg) {
+		t.Errorf("expected warning message %q in output, got:\n%s", msg, got)
+	}
+}
+
+func TestReporter_AddError_AppearsInMarkdown(t *testing.T) {
+	cm := &CostModel{
+		Cluster:          &Cluster{Name: "test"},
+		CPU:              Cost{NonSpot: 1},
+		RAM:              Cost{NonSpot: 1},
+		PersistentVolume: Cost{NonSpot: 1},
+	}
+	req := Requirements{
+		CPUPerPod:    100,
+		MemoryPerPod: 1024 * 1024 * 1024,
+		Replicas:     1,
+		Kind:         "Deployment",
+		Namespace:    "ns",
+		Name:         "wk",
+	}
+
+	const msg = "Mimir replicas query failed for ns/Deployment/wk: timeout"
+	var s strings.Builder
+	r := New(&s, string(Markdown))
+	r.AddReport(cm, req, req)
+	r.AddError(msg)
+	if err := r.Write(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	got := s.String()
+	if !strings.Contains(got, ":exclamation: Errors") {
+		t.Errorf("expected :exclamation: section in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, msg) {
+		t.Errorf("expected error message %q in output, got:\n%s", msg, got)
+	}
+}

--- a/pkg/costmodel/reporter_test.go
+++ b/pkg/costmodel/reporter_test.go
@@ -30,15 +30,17 @@ func TestReporter_writeSummary(t *testing.T) {
 	}
 
 	fromRequirements := Requirements{
-		CPU:              1000,
-		Memory:           1024 * 1024 * 1024,
-		PersistentVolume: 1024 * 1024 * 1024,
+		CPUPerPod:              1000,
+		MemoryPerPod:           1024 * 1024 * 1024,
+		PersistentVolumePerPod: 1024 * 1024 * 1024,
+		Replicas:               1,
 	}
 
 	toRequirements := Requirements{
-		CPU:              2000,
-		Memory:           1024 * 1024 * 1024 * 2,
-		PersistentVolume: 1024 * 1024 * 1024 * 2,
+		CPUPerPod:              2000,
+		MemoryPerPod:           1024 * 1024 * 1024 * 2,
+		PersistentVolumePerPod: 1024 * 1024 * 1024 * 2,
+		Replicas:               1,
 	}
 
 	t.Run("Test a summary with an empty report", func(t *testing.T) {
@@ -182,43 +184,49 @@ func Test_calculateTotalCostForPeriod(t *testing.T) {
 		"no change should result in no cost": {
 			cm: cm,
 			from: Requirements{
-				CPU:              1,
-				Memory:           1,
-				PersistentVolume: 1,
+				CPUPerPod:              1,
+				MemoryPerPod:           1,
+				PersistentVolumePerPod: 1,
+				Replicas:               1,
 			},
 			to: Requirements{
-				CPU:              1,
-				Memory:           1,
-				PersistentVolume: 1,
+				CPUPerPod:              1,
+				MemoryPerPod:           1,
+				PersistentVolumePerPod: 1,
+				Replicas:               1,
 			},
 			changeMultiplier: 1,
 		},
 		"double in resources should result in a double in cost": {
 			cm: cm,
 			from: Requirements{
-				CPU:              1000,
-				Memory:           1024 * 1024 * 1024,
-				PersistentVolume: 1000,
+				CPUPerPod:              1000,
+				MemoryPerPod:           1024 * 1024 * 1024,
+				PersistentVolumePerPod: 1000,
+				Replicas:               1,
 			},
 
 			to: Requirements{
-				CPU:              2000,
-				Memory:           1024 * 1024 * 1024 * 2,
-				PersistentVolume: 2000,
+				CPUPerPod:              2000,
+				MemoryPerPod:           1024 * 1024 * 1024 * 2,
+				PersistentVolumePerPod: 2000,
+				Replicas:               1,
 			},
 			changeMultiplier: 2,
 		},
 		"halving in resources should result in a halving in cost": {
 			cm: cm,
 			from: Requirements{
-				CPU:              1000,
-				Memory:           1024 * 1024 * 1024,
-				PersistentVolume: 1000,
+				CPUPerPod:              1000,
+				MemoryPerPod:           1024 * 1024 * 1024,
+				PersistentVolumePerPod: 1000,
+				Replicas:               1,
 			},
 			to: Requirements{
-				CPU:              500,
-				Memory:           1024 * 1024 * 1024 / 2,
-				PersistentVolume: 500,
+				CPUPerPod:              500,
+				MemoryPerPod:           1024 * 1024 * 1024 / 2,
+				PersistentVolumePerPod: 500,
+				Replicas:               1,
 			},
 			changeMultiplier: 0.5,
 		},

--- a/pkg/costmodel/reporter_test.go
+++ b/pkg/costmodel/reporter_test.go
@@ -2,6 +2,7 @@ package costmodel
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -289,6 +290,110 @@ func TestReporter_AddWarning_AppearsInMarkdown(t *testing.T) {
 	if !strings.Contains(got, msg) {
 		t.Errorf("expected warning message %q in output, got:\n%s", msg, got)
 	}
+}
+
+func TestReporter_AddReportWithResolvedReplicas(t *testing.T) {
+	ctx := context.Background()
+	cm := &CostModel{
+		Cluster:          &Cluster{Name: "pop-prod-aws-northcalifornia-0"},
+		CPU:              Cost{NonSpot: 0.0258},
+		RAM:              Cost{NonSpot: 0.0029},
+		PersistentVolume: Cost{Dollars: 0},
+	}
+	from := Requirements{
+		CPUPerPod:    100, // 100 millicores
+		MemoryPerPod: 1024 * 1024 * 1024,
+		Replicas:     1,
+		Kind:         "Deployment",
+		Namespace:    "sm-k6-mq",
+		Name:         "sm-k6-mq-runner-browser",
+	}
+	to := from
+	to.CPUPerPod = 2000 // simulate the PR-566058 jump
+
+	t.Run("HPA-managed Deployment substitutes observed and warns", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: "keda-hpa-sm-k6-mq-runner-browser", observed: 878}
+		var s strings.Builder
+		r := New(&s, string(Markdown))
+		r.AddReportWithResolvedReplicas(ctx, fr, cm, from, to)
+		if err := r.Write(); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		got := s.String()
+
+		if !strings.Contains(got, ":warning:") {
+			t.Errorf("expected :warning: section, got:\n%s", got)
+		}
+		if !strings.Contains(got, "observed 878 replicas") {
+			t.Errorf("expected substitution warning mentioning 878, got:\n%s", got)
+		}
+		if !strings.Contains(got, "manifest: 1") {
+			t.Errorf("expected warning to mention manifest replicas, got:\n%s", got)
+		}
+		if !strings.Contains(got, "sm-k6-mq-runner-browser") {
+			t.Errorf("expected warning to mention workload name, got:\n%s", got)
+		}
+		// to.CPUPerPod=2000m × 878 replicas = 1756 cores × $0.0258/core/hour × 730h ≈ $33072
+		// Manifest-only path would have produced ~$37/month.
+		if !strings.Contains(got, "$33") && !strings.Contains(got, "$32") {
+			t.Errorf("expected scaled-up cost ($32k–$33k range) in report, got:\n%s", got)
+		}
+	})
+
+	t.Run("non-HPA Deployment uses manifest replicas and emits no warning", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: ""}
+		var s strings.Builder
+		r := New(&s, string(Markdown))
+		r.AddReportWithResolvedReplicas(ctx, fr, cm, from, to)
+		if err := r.Write(); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		got := s.String()
+		if strings.Contains(got, ":warning:") {
+			t.Errorf("did not expect warning section, got:\n%s", got)
+		}
+		if fr.observedCalls != 0 {
+			t.Errorf("observed should not be queried when no HPA, got %d", fr.observedCalls)
+		}
+	})
+
+	t.Run("unsupported kind falls back to manifest path", func(t *testing.T) {
+		fr := &fakeResolver{}
+		var s strings.Builder
+		r := New(&s, string(Markdown))
+		dsFrom := from
+		dsFrom.Kind = "DaemonSet"
+		dsTo := to
+		dsTo.Kind = "DaemonSet"
+		r.AddReportWithResolvedReplicas(ctx, fr, cm, dsFrom, dsTo)
+		if err := r.Write(); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		got := s.String()
+		if strings.Contains(got, ":warning:") {
+			t.Errorf("did not expect warning section for DaemonSet, got:\n%s", got)
+		}
+		if fr.hpaCalls != 0 {
+			t.Errorf("HPATargeting should not be called for DaemonSet, got %d", fr.hpaCalls)
+		}
+	})
+
+	t.Run("HPA detected but observed empty surfaces error and keeps manifest replicas", func(t *testing.T) {
+		fr := &fakeResolver{hpaName: "keda-hpa-foo", observedErr: ErrNoResults}
+		var s strings.Builder
+		r := New(&s, string(Markdown))
+		r.AddReportWithResolvedReplicas(ctx, fr, cm, from, to)
+		if err := r.Write(); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		got := s.String()
+		if !strings.Contains(got, ":exclamation:") {
+			t.Errorf("expected :exclamation: section on resolver error, got:\n%s", got)
+		}
+		if !strings.Contains(got, "sm-k6-mq-runner-browser") {
+			t.Errorf("expected error to mention workload, got:\n%s", got)
+		}
+	})
 }
 
 func TestReporter_AddError_AppearsInMarkdown(t *testing.T) {

--- a/pkg/costmodel/requirements.go
+++ b/pkg/costmodel/requirements.go
@@ -16,22 +16,40 @@ import (
 // the manifest is unknown to the parser.
 var ErrUnknownKind = errors.New("unknown kind")
 
-// Requirements is a struct that holds the aggergated amount of resources for a given manifest file.
-// CPU and Memory are in millicores and bytes respectively and are the sum of all containers in a pod.
-// TODO: Calculate the amount of persistent volume required for a given manifest. This will require finding the associated PVC and calculating the size of the volume.
+// Requirements holds the per-pod resource requirements parsed from a manifest,
+// plus the replica count needed to compute aggregate cost.
+// CPUPerPod is in millicores; MemoryPerPod and PersistentVolumePerPod are in bytes.
+// Each PerPod field is the sum across all containers (or PVC templates) in a single pod.
+// Use TotalCPU / TotalMemory / TotalPersistentVolume to get aggregate values across replicas.
 type Requirements struct {
-	CPU              int64
-	Memory           int64
-	PersistentVolume int64
-	Kind             string
-	Namespace        string
-	Name             string
+	CPUPerPod              int64
+	MemoryPerPod           int64
+	PersistentVolumePerPod int64
+	Replicas               int
+	Kind                   string
+	Namespace              string
+	Name                   string
 }
 
-// AddRequirements will increment the resources by the amount specified in the given requirements.
+// AddRequirements increments the per-pod resources by the amount specified.
 func (r *Requirements) AddRequirements(reqs corev1.ResourceRequirements) {
-	r.CPU += reqs.Requests.Cpu().MilliValue()
-	r.Memory += reqs.Requests.Memory().Value()
+	r.CPUPerPod += reqs.Requests.Cpu().MilliValue()
+	r.MemoryPerPod += reqs.Requests.Memory().Value()
+}
+
+// TotalCPU returns aggregate CPU (millicores) across all replicas.
+func (r Requirements) TotalCPU() int64 {
+	return r.CPUPerPod * int64(r.Replicas)
+}
+
+// TotalMemory returns aggregate memory (bytes) across all replicas.
+func (r Requirements) TotalMemory() int64 {
+	return r.MemoryPerPod * int64(r.Replicas)
+}
+
+// TotalPersistentVolume returns aggregate persistent volume (bytes) across all replicas.
+func (r Requirements) TotalPersistentVolume() int64 {
+	return r.PersistentVolumePerPod * int64(r.Replicas)
 }
 
 // ParseManifest will parse a manifest file and return the aggregated amount of resources requested.
@@ -58,7 +76,7 @@ func ParseManifest(src []byte, costModel *CostModel) (Requirements, error) {
 		if x.Spec.Replicas != nil {
 			replicas = int(*x.Spec.Replicas)
 		}
-		addPersistentVolumeClaimRequirements(x.Spec.VolumeClaimTemplates, &r, replicas)
+		addPersistentVolumeClaimRequirements(x.Spec.VolumeClaimTemplates, &r)
 
 	case *appsv1.Deployment:
 		containers = x.Spec.Template.Spec.Containers
@@ -90,7 +108,8 @@ func ParseManifest(src []byte, costModel *CostModel) (Requirements, error) {
 	}
 
 	r.Kind = kind.Kind
-	addContainersRequirements(containers, &r, replicas)
+	r.Replicas = replicas
+	addContainersRequirements(containers, &r)
 	err = addMetadataToRequirements(obj, &r)
 	if err != nil {
 		return r, err
@@ -108,30 +127,30 @@ func addMetadataToRequirements(obj runtime.Object, requirements *Requirements) e
 	return nil
 }
 
-// addPersistentVolumeClaimRequirements will add the resources requested by the given persistent volume claims to the given requirements.
-func addPersistentVolumeClaimRequirements(templates []corev1.PersistentVolumeClaim, r *Requirements, replicas int) {
+// addPersistentVolumeClaimRequirements adds per-pod PVC storage to the given requirements.
+func addPersistentVolumeClaimRequirements(templates []corev1.PersistentVolumeClaim, r *Requirements) {
 	for _, template := range templates {
-		r.PersistentVolume += int64(replicas) * template.Spec.Resources.Requests.Storage().Value()
+		r.PersistentVolumePerPod += template.Spec.Resources.Requests.Storage().Value()
 	}
 }
 
-// addContainersRequirements will add the resources requested by the given containers to the given requirements.
-// If the number of replicas is greater than 1, the resources will be multiplied by the number of replicas.
-func addContainersRequirements(containers []corev1.Container, r *Requirements, replicas int) {
+// addContainersRequirements adds per-pod container CPU and memory to the given requirements.
+func addContainersRequirements(containers []corev1.Container, r *Requirements) {
 	for _, container := range containers {
 		resources := container.Resources
-		r.CPU += resources.Requests.Cpu().MilliValue() * int64(replicas)
-		r.Memory += resources.Requests.Memory().Value() * int64(replicas)
+		r.CPUPerPod += resources.Requests.Cpu().MilliValue()
+		r.MemoryPerPod += resources.Requests.Memory().Value()
 	}
 }
 
-// Delta returns the difference between two resources.
+// Delta returns the field-wise difference between two resources.
 // A positive value signals that the resource has increased.
 // A negative value signals that the resource has decreased.
 func Delta(from, to Requirements) Requirements {
 	return Requirements{
-		CPU:              to.CPU - from.CPU,
-		Memory:           to.Memory - from.Memory,
-		PersistentVolume: to.PersistentVolume - from.PersistentVolume,
+		CPUPerPod:              to.CPUPerPod - from.CPUPerPod,
+		MemoryPerPod:           to.MemoryPerPod - from.MemoryPerPod,
+		PersistentVolumePerPod: to.PersistentVolumePerPod - from.PersistentVolumePerPod,
+		Replicas:               to.Replicas - from.Replicas,
 	}
 }

--- a/pkg/costmodel/requirements_test.go
+++ b/pkg/costmodel/requirements_test.go
@@ -34,63 +34,70 @@ func TestParseManifest(t *testing.T) {
 
 	tests := map[string]Requirements{
 		"Deployment": {
-			CPU:       cpu("500m"),
-			Memory:    mem("1000Mi"),
-			Kind:      "Deployment",
-			Namespace: "opencost",
-			Name:      "prom-label-proxy",
+			CPUPerPod:    cpu("500m"),
+			MemoryPerPod: mem("1000Mi"),
+			Replicas:     1,
+			Kind:         "Deployment",
+			Namespace:    "opencost",
+			Name:         "prom-label-proxy",
 		},
 		"Job": {
-			CPU:       cpu("50m"),
-			Memory:    mem("200Mi"),
-			Kind:      "Job",
-			Namespace: "hosted-grafana",
-			Name:      "hosted-grafana-source-ips-update-27973440",
+			CPUPerPod:    cpu("50m"),
+			MemoryPerPod: mem("200Mi"),
+			Replicas:     1,
+			Kind:         "Job",
+			Namespace:    "hosted-grafana",
+			Name:         "hosted-grafana-source-ips-update-27973440",
 		},
 
 		"StatefulSet": {
-			CPU:              cpu("1"),
-			Memory:           mem("4Gi"),
-			PersistentVolume: pv("32Gi"),
-			Kind:             "StatefulSet",
-			Namespace:        "opencost",
-			Name:             "opencost",
+			CPUPerPod:              cpu("1"),
+			MemoryPerPod:           mem("4Gi"),
+			PersistentVolumePerPod: pv("32Gi"),
+			Replicas:               1,
+			Kind:                   "StatefulSet",
+			Namespace:              "opencost",
+			Name:                   "opencost",
 		},
 
 		"DaemonSet": {
-			CPU:       cpu("50m"),
-			Memory:    mem("50Mi"),
-			Kind:      "DaemonSet",
-			Namespace: "conntrack-exporter",
-			Name:      "conntrack-exporter",
+			CPUPerPod:    cpu("50m"),
+			MemoryPerPod: mem("50Mi"),
+			Replicas:     1,
+			Kind:         "DaemonSet",
+			Namespace:    "conntrack-exporter",
+			Name:         "conntrack-exporter",
 		},
 
 		"Pod": {
-			CPU:       cpu("45"),
-			Memory:    mem("320Gi"),
-			Kind:      "Pod",
-			Namespace: "default",
-			Name:      "prometheus-0",
+			CPUPerPod:    cpu("45"),
+			MemoryPerPod: mem("320Gi"),
+			Replicas:     1,
+			Kind:         "Pod",
+			Namespace:    "default",
+			Name:         "prometheus-0",
 		},
 
 		// Multi-container manifests
 		"StatefulSet-with-2-containers": {
-			CPU:              cpu("1") + cpu("10m"),
-			Memory:           mem("4Gi") + mem("55M"),
-			PersistentVolume: pv("32Gi"),
-			Kind:             "StatefulSet",
-			Namespace:        "opencost",
-			Name:             "opencost",
+			CPUPerPod:              cpu("1") + cpu("10m"),
+			MemoryPerPod:           mem("4Gi") + mem("55M"),
+			PersistentVolumePerPod: pv("32Gi"),
+			Replicas:               1,
+			Kind:                   "StatefulSet",
+			Namespace:              "opencost",
+			Name:                   "opencost",
 		},
 
 		// With replicas
 		"StatefulSet-with-replicas": {
-			CPU:              2 * cpu("45"),
-			Memory:           2 * mem("320Gi"),
-			PersistentVolume: 2 * pv("7500Gi"),
-			Kind:             "StatefulSet",
-			Namespace:        "default",
-			Name:             "prometheus",
+			CPUPerPod:              cpu("45"),
+			MemoryPerPod:           mem("320Gi"),
+			PersistentVolumePerPod: pv("7500Gi"),
+			Replicas:               2,
+			Kind:                   "StatefulSet",
+			Namespace:              "default",
+			Name:                   "prometheus",
 		},
 	}
 
@@ -127,12 +134,13 @@ func TestParseManifest(t *testing.T) {
 		}
 
 		exp := Requirements{
-			CPU:              cpu("200m"),
-			Memory:           mem("1Gi"),
-			PersistentVolume: pv("100Gi"),
-			Kind:             "StatefulSet",
-			Namespace:        "alertmanager",
-			Name:             "alertmanager",
+			CPUPerPod:              cpu("200m"),
+			MemoryPerPod:           mem("1Gi"),
+			PersistentVolumePerPod: pv("100Gi"),
+			Replicas:               1,
+			Kind:                   "StatefulSet",
+			Namespace:              "alertmanager",
+			Name:                   "alertmanager",
 		}
 
 		if exp != got {
@@ -161,44 +169,44 @@ func TestDelta(t *testing.T) {
 	}{
 		"Two equal resources should result in all values being zero": {
 			from: Requirements{
-				CPU:    1,
-				Memory: 2,
+				CPUPerPod:    1,
+				MemoryPerPod: 2,
 			},
 			to: Requirements{
-				CPU:    1,
-				Memory: 2,
+				CPUPerPod:    1,
+				MemoryPerPod: 2,
 			},
 			want: Requirements{
-				CPU:    0,
-				Memory: 0,
+				CPUPerPod:    0,
+				MemoryPerPod: 0,
 			},
 		},
 		"Two resources with more resources should result in the correct positive delta": {
 			from: Requirements{
-				CPU:    1,
-				Memory: 2,
+				CPUPerPod:    1,
+				MemoryPerPod: 2,
 			},
 			to: Requirements{
-				CPU:    2,
-				Memory: 4,
+				CPUPerPod:    2,
+				MemoryPerPod: 4,
 			},
 			want: Requirements{
-				CPU:    1,
-				Memory: 2,
+				CPUPerPod:    1,
+				MemoryPerPod: 2,
 			},
 		},
 		"To resources with less resources should result in the correct negative delta": {
 			from: Requirements{
-				CPU:    2,
-				Memory: 4,
+				CPUPerPod:    2,
+				MemoryPerPod: 4,
 			},
 			to: Requirements{
-				CPU:    1,
-				Memory: 2,
+				CPUPerPod:    1,
+				MemoryPerPod: 2,
 			},
 			want: Requirements{
-				CPU:    -1,
-				Memory: -2,
+				CPUPerPod:    -1,
+				MemoryPerPod: -2,
 			},
 		},
 	}


### PR DESCRIPTION
This implements a long requested feature to handle scenarios where the deployment/statefulset has it's replicas managed via either VPA or KEDA. I've built the feature up incremenetally so you can follow each commit to see the intent. The changeset is quite large, but a majority of it is testing out the implementation details!

Introduces a new method in reporter: `AddReportWithResolvedReplicas` that creates a client dependant on the cluster _and_ if the workload has hpa enabled for it. If the workload does use hpa in some form, another query is sent to Mimir to gather the average amount of replicas running over a 7 day period. This value is then used in the report to estimate the change of cost for the workload.

Here's a view of it live: https://github.com/grafana/deployment_tools/pull/573137#issuecomment-4360697555
