### PR TITLE
Upgrade golangci-lint to v2.4.0 for Go 1.25 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ jobs:
         run: go build -v ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         with:
-          version: v1.64.8
+          version: v2.4.0
 
       - name: Test
         run: go test -v ./...

--- a/pkg/costmodel/client_test.go
+++ b/pkg/costmodel/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -153,25 +154,15 @@ func TestNewClientAuthMethods(t *testing.T) {
 	})
 
 	t.Run("basic auth with http config file", func(t *testing.T) {
-		tmpCfg, err := os.CreateTemp("", "http_config.yaml")
-		if err != nil {
-			t.Errorf("error creating temp file: %v", err)
-			return
-		}
-		t.Cleanup(func() {
-			if err := os.Remove(tmpCfg.Name()); err != nil {
-				t.Errorf("failed to remove temp file: %v", err)
-			}
-		})
+		tmpPath := filepath.Join(t.TempDir(), "http_config.yaml")
 		content := fmt.Sprintf("basic_auth:\n  username: %s\n  password: %s", "testing", "12345")
-		_, err = tmpCfg.WriteString(content)
-		if err != nil {
-			t.Errorf("error writing to temp file: %v", err)
+		if err := os.WriteFile(tmpPath, []byte(content), 0o644); err != nil {
+			t.Errorf("error writing temp file: %v", err)
 			return
 		}
 		cfg := &ClientConfig{
 			Address:        "http://localhost:9090",
-			HTTPConfigFile: tmpCfg.Name(),
+			HTTPConfigFile: tmpPath,
 		}
 		client, err := NewClient(cfg)
 		if err != nil {

--- a/pkg/costmodel/client_test.go
+++ b/pkg/costmodel/client_test.go
@@ -158,7 +158,11 @@ func TestNewClientAuthMethods(t *testing.T) {
 			t.Errorf("error creating temp file: %v", err)
 			return
 		}
-		defer os.Remove(tmpCfg.Name())
+		t.Cleanup(func() {
+			if err := os.Remove(tmpCfg.Name()); err != nil {
+				t.Errorf("failed to remove temp file: %v", err)
+			}
+		})
 		content := fmt.Sprintf("basic_auth:\n  username: %s\n  password: %s", "testing", "12345")
 		_, err = tmpCfg.WriteString(content)
 		if err != nil {

--- a/pkg/costmodel/reporter.go
+++ b/pkg/costmodel/reporter.go
@@ -167,13 +167,17 @@ func (r *Reporter) writeSummary() error {
 		fmt.Sprintf("PR changed the overall cost by %s(%.1f%%).", displayCostInDollars(totalDiff), percentageChange(fromTotalCost, toTotalCost)),
 		fmt.Sprintf("Total Monthly Cost went from $%.2f to $%.2f.", fromTotalCost, toTotalCost),
 	)
-	fmt.Fprintln(r.Writer, strings.Join(rows, "\n"))
+	if _, err := fmt.Fprintln(r.Writer, strings.Join(rows, "\n")); err != nil {
+		return err
+	}
 	return tabwriter.Flush()
 }
 
 func (r *Reporter) writeTable() error {
 	tabWriter := tabwriter.NewWriter(r.Writer, 8, 6, 2, ' ', 0)
-	fmt.Fprintln(tabWriter, strings.Join(headers, "\t"))
+	if _, err := fmt.Fprintln(tabWriter, strings.Join(headers, "\t")); err != nil {
+		return err
+	}
 	totalCosts := make(map[string]float64)
 
 	for _, m := range r.reports {
@@ -193,7 +197,9 @@ func (r *Reporter) writeTable() error {
 			totalCosts[keys.To] += toCost
 		}
 
-		fmt.Fprintln(tabWriter, strings.Join(row, "\t"))
+		if _, err := fmt.Fprintln(tabWriter, strings.Join(row, "\t")); err != nil {
+			return err
+		}
 	}
 
 	// If there are multiple models, print a Total Costs row.
@@ -209,7 +215,9 @@ func (r *Reporter) writeTable() error {
 			)
 		}
 
-		fmt.Fprintln(tabWriter, strings.Join(row, "\t"))
+		if _, err := fmt.Fprintln(tabWriter, strings.Join(row, "\t")); err != nil {
+			return err
+		}
 	}
 
 	return tabWriter.Flush()


### PR DESCRIPTION
* Bump golangci-lint from v1.64.8 to v2.4.0 (minimum version with Go 1.25 support)
* Update golangci-lint-action to v9.2.1
* Address linter errors.

Unblocks [#120](https://github.com/grafana/Kost/pull/120), which fails CI because v1.64.x cannot lint a Go 1.25.10 toolchain target.

CI on #120: only build-lint-test fails ([run 26519513343](https://github.com/grafana/Kost/actions/runs/26519513343)):
```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint 
is lower than the targeted Go version (1.25.10)
Failed executing command with error: can't load config: ...
##[error]golangci-lint exit with code 3
```