### PR TITLE
ci: bump golangci-lint to v2.12.2 for go 1.26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         with:
-          version: v2.4.0
+          version: v2.12.2
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
## What

Bump the `golangci-lint` version in the `Tests` workflow from `v2.4.0` to `v2.12.2`.

## Why

`golangci-lint v2.4.0` is built with Go 1.25 and refuses to lint a module whose `go` directive targets a higher version:

```
can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.0)
```

The Kubernetes monorepo bump (#135) raises the `go` directive to `1.26.0`, which trips this check. `v2.12.2` is built with `go1.26.2`, so it lints `1.26.0` modules cleanly.

Splitting this out of #135 keeps that PR a pure dependency update and makes the linter fix durable for every future Go 1.26 PR.

## Verification

Ran `golangci-lint v2.12.2` locally against the `go 1.26.0` module: `0 issues`.